### PR TITLE
Implement CRA TypeScript rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,41 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       rules: {
         '@typescript-eslint/no-namespace': 'error',
+        'default-case': 'off',
+        'no-dupe-class-members': 'off',
+        'no-undef': 'off',
+        '@typescript-eslint/consistent-type-assertions': 'warn',
+        'no-array-constructor': 'off',
+        '@typescript-eslint/no-array-constructor': 'warn',
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': [
+          'warn',
+          {
+            functions: false,
+            classes: false,
+            variables: false,
+            typedefs: false,
+          },
+        ],
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+          'error',
+          {
+            allowShortCircuit: true,
+            allowTernary: true,
+            allowTaggedTemplates: true,
+          },
+        ],
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          {
+            args: 'none',
+            ignoreRestSiblings: true,
+          },
+        ],
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'warn',
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const path = require('path')
 
 module.exports = {
   parser: 'babel-eslint',
-  plugins: ['react', 'react-hooks', 'prettier', 'order'],
+  plugins: ['react', 'react-hooks', 'import'],
 
   env: {
     browser: true,
@@ -21,11 +21,13 @@ module.exports = {
   },
 
   extends: [
-    'plugin:prettier/recommended',
     'plugin:react/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',
+    'prettier',
+    'prettier/react',
+    'prettier/@typescript-eslint',
   ],
 
   overrides: [
@@ -98,7 +100,7 @@ module.exports = {
     'import/default': 'off',
     'import/named': 'warn',
     'react/require-render-return': 'error',
-    'react/prop-types': 'off'  // No need for prop type validation with TypeScript
+    'react/prop-types': 'off', // No need for prop type validation with TypeScript
     'react-hooks/rules-of-hooks': 'error',
     'import/order': [
       'error',

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "eslint": "6.x"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.6.0",
-    "@typescript-eslint/parser": "2.6.0",
+    "@typescript-eslint/eslint-plugin": "2.12.0",
+    "@typescript-eslint/parser": "2.12.0",
     "babel-eslint": "10.0.3",
+    "eslint-config-prettier": "6.7.0",
     "eslint-import-resolver-typescript": "2.0.0",
-    "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-prettier": "3.1.1",
-    "eslint-plugin-react": "7.16.0",
-    "eslint-plugin-react-hooks": "2.2.0"
+    "eslint-plugin-import": "2.19.1",
+    "eslint-plugin-react": "7.17.0",
+    "eslint-plugin-react-hooks": "2.3.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
This implements a bunch of TypeScript specific rules based on what Create React App uses.
Most important is that it disables some JS rules and replaces it with the TypeScript version when using TypeScript files.